### PR TITLE
simplifying api - abstract general patterns in Glue construction

### DIFF
--- a/examples/multiple/BubblingCounter.elm
+++ b/examples/multiple/BubblingCounter.elm
@@ -1,0 +1,72 @@
+module Multiple.BubblingCounter exposing (Model, Msg, init, update, view)
+
+import Html exposing (Html)
+import Html.Events
+import Cmd.Extra
+
+
+-- Model
+
+
+type alias Model =
+    Int
+
+
+init : msg -> ( Model, Cmd msg )
+init msg =
+    let
+        model =
+            0
+    in
+        ( model, notifyEven msg model )
+
+
+
+-- update
+
+
+type Msg
+    = Increment
+    | Decrement
+
+
+isEven : Int -> Bool
+isEven =
+    (==) 0 << (Basics.flip (%)) 2
+
+
+notifyEven : msg -> Model -> Cmd msg
+notifyEven msg model =
+    if isEven model then
+        Cmd.Extra.perform msg
+    else
+        Cmd.none
+
+
+update : msg -> Msg -> Model -> ( Model, Cmd msg )
+update notify msg model =
+    let
+        newModel =
+            case msg of
+                Increment ->
+                    model + 1
+
+                Decrement ->
+                    model - 1
+    in
+        ( newModel, notifyEven notify newModel )
+
+
+
+-- View
+
+
+view : (Msg -> msg) -> Model -> Html msg
+view msg model =
+    Html.map msg <|
+        Html.div
+            []
+            [ Html.button [ Html.Events.onClick Decrement ] [ Html.text "-" ]
+            , Html.text <| toString model
+            , Html.button [ Html.Events.onClick Increment ] [ Html.text "+" ]
+            ]

--- a/examples/multiple/Counter.elm
+++ b/examples/multiple/Counter.elm
@@ -1,0 +1,53 @@
+module Multiple.Counter exposing (Model, Msg, init, update, view)
+
+import Html exposing (Html)
+import Html.Events
+
+
+-- Model
+
+
+type alias Model =
+    Int
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( 0, Cmd.none )
+
+
+
+-- update
+
+
+type Msg
+    = Increment
+    | Decrement
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    let
+        newModel =
+            case msg of
+                Increment ->
+                    model + 1
+
+                Decrement ->
+                    model - 1
+    in
+        ( newModel, Cmd.none )
+
+
+
+-- View
+
+
+view : Model -> Html Msg
+view model =
+    Html.div
+        []
+        [ Html.button [ Html.Events.onClick Decrement ] [ Html.text "-" ]
+        , Html.text <| toString model
+        , Html.button [ Html.Events.onClick Increment ] [ Html.text "+" ]
+        ]

--- a/examples/multiple/Main.elm
+++ b/examples/multiple/Main.elm
@@ -61,12 +61,14 @@ moves =
 
 bubblingcounter : Glue Model BubblingCounter.Model Msg BubblingCounter.Msg
 bubblingcounter =
-    Glue.glue
-        { model = \subModel model -> { model | bubblingcounter = subModel }
+    Glue.bubbling
+        { modelsetter = \subModel model -> { model | bubblingcounter = subModel }
+        , modelgetter = .bubblingcounter
         , init = BubblingCounter.init Even
-        , update = \subMsg model -> BubblingCounter.update Even subMsg model.bubblingcounter
-        , view = \model -> BubblingCounter.view BubblingCounterMsg model.bubblingcounter
+        , update = BubblingCounter.update Even
+        , view = BubblingCounter.view BubblingCounterMsg
         , subscriptions = \_ -> Sub.none
+        , liftmessage = BubblingCounterMsg
         }
 
 

--- a/examples/multiple/Main.elm
+++ b/examples/multiple/Main.elm
@@ -1,0 +1,221 @@
+module Multiple.Main exposing (main)
+
+import Html exposing (Html)
+import Mouse exposing (Position)
+
+
+-- Library
+
+import Glue exposing (Glue)
+
+
+-- Submodules
+
+import Multiple.Counter as Counter
+import Multiple.BubblingCounter as BubblingCounter
+import Multiple.Moves as Moves
+
+
+counter : Glue Model Counter.Model Msg Counter.Msg
+counter =
+    Glue.createglue
+        { modelsetter = \subModel model -> { model | counter = subModel }
+        , modelgetter = .counter
+        , init = Counter.init
+        , update = Counter.update
+        , view = Counter.view
+        , subscriptions = \_ -> Sub.none
+        , liftmessage = CounterMsg
+        }
+
+
+counter2 : Glue Model Counter.Model Msg Counter.Msg
+counter2 =
+    Glue.createglue
+        { modelsetter = \subModel model -> { model | counter2 = subModel }
+        , modelgetter = .counter2
+        , init = Counter.init
+        , update = Counter.update
+        , view = Counter.view
+        , subscriptions = \_ -> Sub.none
+        , liftmessage = Counter2Msg
+        }
+
+
+moves : Glue Model Moves.Model Msg Moves.Msg
+moves =
+    Glue.createglue
+        { modelsetter = \subModel model -> { model | moves = subModel }
+        , modelgetter = .moves
+        , init = Moves.init
+        , update = Moves.update
+        , view = Moves.view
+        , subscriptions = Moves.subscriptions
+        , liftmessage = MovesMsg
+        }
+
+
+
+-- bubblingcounter has a non-standard type definition can't use createglue use glue instead
+
+
+bubblingcounter : Glue Model BubblingCounter.Model Msg BubblingCounter.Msg
+bubblingcounter =
+    Glue.glue
+        { model = \subModel model -> { model | bubblingcounter = subModel }
+        , init = BubblingCounter.init Even
+        , update = \subMsg model -> BubblingCounter.update Even subMsg model.bubblingcounter
+        , view = \model -> BubblingCounter.view BubblingCounterMsg model.bubblingcounter
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+
+-- Main
+
+
+localsubscriptions : Model -> Sub Msg
+localsubscriptions model =
+    Mouse.clicks Clicked
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }
+
+
+subscriptions : Model -> Sub Msg
+subscriptions =
+    localsubscriptions
+        |> Glue.subscriptions counter
+        |> Glue.subscriptions counter2
+        |> Glue.subscriptions moves
+        |> Glue.subscriptions bubblingcounter
+
+
+counterlist : List (Glue Model Counter.Model Msg Counter.Msg)
+counterlist =
+    [ counter, counter2 ]
+
+
+
+-- Model
+
+
+type alias Model =
+    { message : String
+    , clicks : Int
+    , even : Bool
+    , moves : Moves.Model
+    , bubblingcounter : BubblingCounter.Model
+    , counter : Counter.Model
+    , counter2 : Counter.Model
+    }
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( Model "Let's change cunter!" 0 False
+    , Cmd.none
+    )
+        |> Glue.init moves
+        |> Glue.init bubblingcounter
+        |> Glue.init counter
+        |> Glue.init counter2
+
+
+
+-- Update
+
+
+type Msg
+    = CounterMsg Counter.Msg
+    | Counter2Msg Counter.Msg
+    | Clicked Position
+    | MovesMsg Moves.Msg
+    | BubblingCounterMsg BubblingCounter.Msg
+    | Even
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        CounterMsg counterMsg ->
+            ( { model | message = "Counter has changed!" }, Cmd.none )
+                |> Glue.update counter counterMsg
+
+        MovesMsg movesMsg ->
+            ( model, Cmd.none )
+                |> Glue.update moves movesMsg
+
+        Clicked _ ->
+            ( { model | clicks = model.clicks + 1 }, Cmd.none )
+
+        BubblingCounterMsg bubblingcounterMsg ->
+            ( { model | even = False }, Cmd.none )
+                |> Glue.update bubblingcounter bubblingcounterMsg
+
+        Even ->
+            ( { model | even = True }, Cmd.none )
+
+        Counter2Msg counterMsg ->
+            ( model, Cmd.none )
+                |> Glue.update counter2 counterMsg
+
+
+
+-- View
+
+
+view : Model -> Html Msg
+view model =
+    Html.div []
+        [ counterview model
+        , movesview model
+        , bubblingcounterview model
+        , counter2view model
+        ]
+
+
+movesview : Model -> Html Msg
+movesview model =
+    Html.div []
+        [ Html.text <| "Clicks: " ++ (toString model.clicks)
+        , Html.div []
+            [ Html.text "Position: "
+            , Glue.view moves model
+            ]
+        ]
+
+
+counterview : Model -> Html Msg
+counterview model =
+    Html.div []
+        [ Html.text model.message
+        , Glue.view counter
+            model
+        ]
+
+
+counter2view : Model -> Html Msg
+counter2view model =
+    Html.div []
+        [ Glue.view counter2
+            model
+        ]
+
+
+bubblingcounterview : Model -> Html Msg
+bubblingcounterview model =
+    Html.div []
+        [ Glue.view bubblingcounter model
+        , if model.even then
+            Html.text "is even"
+          else
+            Html.text "is odd"
+        ]

--- a/examples/multiple/Moves.elm
+++ b/examples/multiple/Moves.elm
@@ -1,0 +1,49 @@
+module Multiple.Moves exposing (Model, Msg, init, update, view, subscriptions)
+
+import Html exposing (Html)
+import Mouse exposing (Position)
+
+
+-- Subscriptions
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Mouse.moves Moved
+
+
+
+-- Model
+
+
+type alias Model =
+    Position
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { x = 0, y = 0 }, Cmd.none )
+
+
+
+-- Update
+
+
+type Msg
+    = Moved Position
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Moved position ->
+            position ! []
+
+
+
+-- View
+
+
+view : Model -> Html Msg
+view model =
+    Html.text <| toString model

--- a/src/Glue.elm
+++ b/src/Glue.elm
@@ -1,4 +1,4 @@
-module Glue exposing (Glue, glue, init, update, view, subscriptions, map)
+module Glue exposing (Glue, glue, init, update, view, subscriptions, map, createglue)
 
 {-| Composing Elm applications from smaller isolated parts (modules).
 You can think about this as about lightweight abstraction built around `(model, Cmd msg)` pair
@@ -69,6 +69,52 @@ glue :
     -> Glue model subModel msg subMsg
 glue =
     Glue
+
+
+{-| Create [Glue](#Glue) mapigs between modules.
+child module can be generic TEA app or module that is already doing polymorfic maping to generic `msg` internaly.
+You can also use `Cmd` for sending data from bottom module to upper one if you want to observe child
+as a black box (similary you do in case of DOM events with `Html.Events`).
+
+**Interface**:
+
+    createglue :
+          { modelsetter = \subModel model -> { model | subModel = subModel }
+          , modelgetter = .subModel
+          , init =  ( subModel, Cmd subMsg )
+          , update = subMsg -> subModel -> ( subModel, Cmd msg )
+          , view = subModel -> Html subMsg
+          , subscriptions = subModel -> Sub subMsg
+          , liftmessage = subMsg -> msg
+          }
+        -> Glue model subModel msg subMsg
+
+See [examples](https://github.com/turboMaCk/glue/tree/master/examples) for more informations.
+
+-}
+createglue :
+    { e
+        | init : ( subModel, Cmd subMsg )
+        , liftmessage : subMsg -> msg
+        , modelgetter : model -> subModel
+        , modelsetter : subModel -> model -> model
+        , subscriptions : subModel -> Sub subMsg
+        , update : subMsg -> subModel -> ( subModel, Cmd subMsg )
+        , view : subModel -> Html subMsg
+    }
+    -> Glue model subModel msg subMsg
+createglue config =
+    glue <|
+        { model = config.modelsetter
+        , init = config.init |> map config.liftmessage
+        , update =
+            \subMsg model ->
+                config.modelgetter model
+                    |> config.update subMsg
+                    |> map config.liftmessage
+        , view = \model -> Html.map config.liftmessage <| config.view <| config.modelgetter model
+        , subscriptions = \model -> Sub.map config.liftmessage <| config.subscriptions <| config.modelgetter model
+        }
 
 
 


### PR DESCRIPTION
I had set out to create something like Glue but didn't get everything I had wanted it to do.  Then I came accross Glue and really like it.  One thing I felt was missing was an easy way to create standard Glue objects. 
So a wrote createglue.  Works with most  `(model, Cmd msg)` pair components.  But doesn't work with the bubbling counter example, but you can still do it the same way as previously. Createglue is a helper method to simplify things for the programmer.

Added example with multiple components